### PR TITLE
Divide and conquer the `/tournament start` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,86 @@
 
 ## [Swiss pairings](https://en.wikipedia.org/wiki/Swiss-system_tournament)
 
-`/tournament start swiss:2:PT65M:4 "Netrunner Draft #5" @Alice @Bob Carol @Dave @Eve Frank Grace`
-> Tournament `T1` started.
+`/tournaments`
+> Available commands:
+* game
+* round
+* score
+* tournament
+
+`/tournament`
+> Available `/tournament` sub-commands:
+* create
+* set
+    * title
+    * players
+* use
+    * swiss
+* show
+* start
+
+`/tournament create`
+> Tournament `T1` created.
+
+`/tournament set title Netrunner Draft #5`
+> Tournament `T1` title set.
+
+`/tournament set players Alice Bob Carol Dave Eve Frank Grace`
+> Tournament `T1` players set.
 
 `/tournament show`
-> Tournament `T1` “Netrunner Draft #5” has started on 2016-05-16 17:35.
+> Tournament `T1` "Netrunner Draft #5" has not started yet.
+
+> Participants: Alice, Bob, Carol, Dave, Eve, Frank, Grace.
+
+> It uses no system.
+
+> It is the current tournament.
+
+`/tournament use swiss`
+> Tournament `T1` set to use Swiss Pairings.
+
+`/tournament show`
+> Tournament `T1` "Netrunner Draft #5" has not started yet.
+
+> Participants: Alice, Bob, Carol, Dave, Eve, Frank, Grace.
+
+> It uses Swiss pairings. Number of rounds: 3. Time for each round: 30 minutes. Byes are worth 2 points.
+
+> It is the current tournament.
+
+`/tournament`
+> Available `/tournament` sub-commands:
+* create
+* set
+    * title
+    * players
+    * rounds
+    * round-time
+    * bye-points
+* use
+    * swiss
+* show
+* start
+
+`/tournament set rounds 2`
+> Tournament `T1` number of rounds set.
+
+`/tournament set round-time PT65M`
+> Tournament `T1` time per round set.
+
+`/tournament set bye-points 4`
+> Tournament `T1` points for bye set.
+
+`/tournament start`
+> Tournament `T1` started. It can no longer be edited.
+
+`/tournament show`
+> Tournament `T1` "Netrunner Draft #5" has started on 2016-05-16 17:35.
+
+> Participants: Alice, Bob, Carol, Dave, Eve, Frank, Grace.
 
 > It uses Swiss pairings. Number of rounds: 2. Time for each round: 65 minutes. Byes are worth 4 points.
-
-> Participants: Alice Alpha, Bob Beta, Carol, Dave Delta, Eve Epsilon, Frank, Grace
 
 > It is the current tournament.
 
@@ -18,69 +89,69 @@
 > Round `T1R1` started. It will end on 18:40.
 
 > Games to play:
-* `T1R1G1: Alice Alpha vs Dave Delta`
-* `T1R1G2: Carol vs Eve Epsilon`
-* `T1R1G3: Frank vs Bob Beta`
+* `T1R1G1: Alice vs Dave`
+* `T1R1G2: Carol vs Eve`
+* `T1R1G3: Frank vs Bob`
 
 > Bye given to Grace. An odd number of players results in a bye for a random lowest-ranked player.
 
-`/game add-vs @Carol @Eve 0:2`
+`/game add-vs Carol Eve 0:2`
 > Game `T1R1G2` recorded.
 
 `/round start`
 > Round `T1R2` cannot start until `T1R1` finishes:
-* `T1R1G1: Alice Alpha vs Dave Delta`
-* `T1R1G3: Frank vs Bob Beta`
+* `T1R1G1: Alice vs Dave`
+* `T1R1G3: Frank vs Bob`
 
-`/game add-vs @Alice @Bob 2:2`
+`/game add-vs Alice Bob 2:2`
 > These opponents should not play against each other this round. Command ignored.
 
-`/game update Carol @Eve 2:2`
+`/game update Carol Eve 2:2`
 > Game `T1R1G2` updated.
 
 `/game show G1`
-> Game `T1R1G1: Alice Alpha vs Dave Delta` was not played yet.
+> Game `T1R1G1: Alice vs Dave` was not played yet.
 
 `/game show G2`
-> Game `T1R1G2: Carol vs Eve Epsilon 2:2` was played.
+> Game `T1R1G2: Carol vs Eve 2:2` was played.
 
 `/game add-id G1 4:0`
-> Game `T1R1G1: Alice Alpha vs Dave Delta 4:0` recored.
+> Game `T1R1G1: Alice vs Dave 4:0` recorded.
 
 _65 minutes pass ..._
 
 > Round `T1R1` timed out. The following games should be timed out:
-* `T1R1G3: Frank vs Bob Beta`
+* `T1R1G3: Frank vs Bob`
 
-`/game add-vs @Bob Frank 1:2`
-> Game `T1R1G3: Frank vs Bob Beta 2:1` recorded.
+`/game add-vs Bob Frank 1:2`
+> Game `T1R1G3: Frank vs Bob 2:1` recorded.
 
 > Round `T1R1` finished.
 
 `/score`
 > `T1` current standings:
-* Alice Alpha: 4
+* Alice: 4
 * Grace: 4
 * Carol: 2
-* Eve Epsilon: 2
+* Eve: 2
 * Frank: 2
-* Bob Beta: 1
+* Bob: 1
 * Dave: 0
 
 `/round start`
 > Round `T1R2` started. It will end on 19:50.
 
 > Games to play:
-* `T1R2G1: Alice Alpha vs Grace`
+* `T1R2G1: Alice vs Grace`
 * `T1R2G2: Carol vs Frank`
-* `T1R2G3: Bob Beta vs Eve Epsilon`
+* `T1R2G3: Bob vs Eve`
 
 > Bye given to Dave. An odd number of players results in a bye for a random lowest-ranked player.
 
-`/game add-vs @Bob @Eve 2:2`
+`/game add-vs Bob Eve 2:2`
 > Game `T1R2G3` recorded.
 
-`/game add-vs @Alice Grace 4:0`
+`/game add-vs Alice Grace 4:0`
 > Game `T1R2G1` recorded.
 
 `/game add-vs Carol Frank 0:4`
@@ -92,12 +163,12 @@ _65 minutes pass ..._
 
 `/score`
 > `T1` current standings:
-* Alice Alpha: 8
+* Alice: 8
 * Frank: 6
 * Dave: 4
-* Eve Epsilon: 4
+* Eve: 4
 * Grace: 4
-* Bob Beta: 3
+* Bob: 3
 * Carol: 2
 
 # Development


### PR DESCRIPTION
Previous `/tournament start` API was complex to read, parse and discover.
New API is more extensible by tournament system modules. They can:
- provide additional tournament properties along with their descriptions
- intercept interpretation of `/game` and `/round` calls

Cease to treat HipChat menions specially.
